### PR TITLE
base path correction

### DIFF
--- a/src/Commands/BreadGenerator.php
+++ b/src/Commands/BreadGenerator.php
@@ -139,6 +139,6 @@ class BreadGenerator extends GeneratorCommand
      */
     protected function getStub()
     {
-        return base_path('vendor/jeffochoa/voyager-bread-generator/src/stubs/bread.stub');
+        return base_path('vendor/voyager-bread-generator/src/stubs/bread.stub');
     }
 }


### PR DESCRIPTION
When trying to run: 

`php artisan voyager:bread organizations`

I was getting the following error:

```
[Illuminate\Contracts\Filesystem\FileNotFoundException]
File does not exist at path /home/vagrant/code/vendor/jeffochoa/voyager-bread-generator/src/stubs/bread.stub
```

Updating the base path to the correct location in the vendor directory fixed it.